### PR TITLE
♿Accessibility in home page : ignore icons & list of cards & color co…

### DIFF
--- a/src/components/dsfrComponents/HomeCard.tsx
+++ b/src/components/dsfrComponents/HomeCard.tsx
@@ -15,9 +15,10 @@ const HomeCard: React.FC<CardTypeProps> = (props) => {
   return (
     <>
       <div
+        role="listitem"
         className={`fr-card ${
           isExplorerCard &&
-          'bg-blue-france-main text-blue-france before:bg-blue-france hover:bg-blue-france-main-hover'
+          'bg-blue-france-main text-black before:bg-blue-france hover:bg-blue-france-main-hover'
         }
                 ${!isExplorerCard && isAlpha ? alphaCardStyle : 'fr-enlarge-link'} }
                  m-[1em]
@@ -26,11 +27,11 @@ const HomeCard: React.FC<CardTypeProps> = (props) => {
       >
         <div className="fr-card__body">
           <div className="fr-card__content">
-            <h4 className="fr-card__title">
+            <h3 className="fr-card__title">
               {!isAlpha ? (
                 <a
                   href={searchLink}
-                  className={`${isExplorerCard && 'text-blue-france '}
+                  className={`${isExplorerCard && 'text-black '}
                                     text-lg`}
                 >
                   {title}
@@ -38,16 +39,16 @@ const HomeCard: React.FC<CardTypeProps> = (props) => {
               ) : (
                 <p className="text-lg">{title}</p>
               )}
-            </h4>
+            </h3>
             <p className="fr-card__desc text-base ">{description}</p>
           </div>
         </div>
         <div className="fr-card__header">
           <div className="fr-card__img  p-[2rem] pb-[0]">
             {!isExplorerCard ? (
-              <SVGLogo height="80" width="80" style={{ color: color }} />
+              <SVGLogo height="80" width="80" style={{ color: color }} aria-hidden="true" />
             ) : (
-              <SVGLogo width="80" height="80" />
+              <SVGLogo width="80" height="80" aria-hidden="true" />
             )}
           </div>
         </div>

--- a/src/components/page/HomePagePublicActor.tsx
+++ b/src/components/page/HomePagePublicActor.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { PictoExplorer } from '../../assets/Icons';
 import { useTitle } from '../../hooks/useTitle';
 import { publicActorPersona as publicActorCardType } from '../../model/CardType';
-import HomeCard from '../dsfrComponents/HomeCard';
 
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import HomeCard from '../dsfrComponents/HomeCard';
 export interface ExplorerTypeCard {
   SVGLogo: ({ ...other }: { [x: string]: any }) => JSX.Element;
   title: string;
@@ -67,13 +67,13 @@ const HomePagePublicActor = () => {
                 lg:max-w-[62%]
                 "
         >
-          {' '}
           A partir de la description de votre besoin, nous vous proposons des pistes de leviers
           autour des axes suivants :
         </h2>
       </div>
 
       <div
+        role="list"
         className="cardsContainer mx-auto flex flex-wrap justify-start"
         style={{ width: cardContainerWidth }}
       >

--- a/src/components/page/HomePageStartup.tsx
+++ b/src/components/page/HomePageStartup.tsx
@@ -74,6 +74,7 @@ const HomeStartup = () => {
       </div>
 
       <div
+        role="list"
         className="cardsContainer mx-auto flex flex-wrap justify-start"
         style={{ width: cardContainerWidth }}
       >


### PR DESCRIPTION
…ntrast & structure

Modification d'accessibilité sur le contenu principal de la page Home : 
- Structure des Headings
- Role liste pour les cartes
- Ignorée les icones par les lecteurs d'écrans
- Contraste des couleurs

⚠️ Il va être surement plus simple de merger cette PR avant : https://github.com/ecolabdata/mes-services-greentech/pull/6